### PR TITLE
Note saving hot-fix

### DIFF
--- a/note/src/main/java/io/mjolnir/saltblock/ui/EditNoteActivity.java
+++ b/note/src/main/java/io/mjolnir/saltblock/ui/EditNoteActivity.java
@@ -53,6 +53,8 @@ public class EditNoteActivity extends AppCompatActivity {
                 String titleText = mTitle.getText().toString();
                 String noteText = mNote.getText().toString();
                 viewModel.editNote(uId, titleText, noteText);
+                viewModel.setId(null);
+                finish();
             }
         });
     }


### PR DESCRIPTION
View model was storing id.
Adding new note would update old note.
Clearing id before finishing editing activity.